### PR TITLE
cli: Add OOTB TypeScript support and big build performance improvements

### DIFF
--- a/packages/cli/src/commands/deploy/build.ts
+++ b/packages/cli/src/commands/deploy/build.ts
@@ -18,7 +18,11 @@ function filterByExtension(ext: string) {
   return (v: string) => v.endsWith('.' + ext);
 }
 
-export function build(entryFiles: Array<string> = [], debug: string) {
+export function build(
+  pathDir: string,
+  entryFiles: Array<string> = [],
+  debug: string
+) {
   return new Promise<Bundle>(async (resolve, reject) => {
     const entryFilesWithName: Record<string, string> = {};
 
@@ -50,12 +54,30 @@ export function build(entryFiles: Array<string> = [], debug: string) {
           }),
         ] as any,
       },
+      cache: {
+        type: 'filesystem' as const,
+        name: 'deployment',
+        cacheLocation: path.join(
+          pathDir,
+          '.fleet',
+          'cache',
+          'webpack',
+          'stage-deployment'
+        ),
+      },
       module: {
         rules: [
           {
-            include: /node_modules/,
-            test: /\.mjs$/,
-            type: 'javascript/auto',
+            test: [/.js$/, /.ts$/],
+            exclude: /node_modules/,
+            use: {
+              loader: 'babel-loader',
+              options: {
+                cacheCompression: false,
+                cacheDirectory: true,
+                presets: [require('@babel/preset-typescript')],
+              },
+            },
           },
         ],
       },

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -123,7 +123,7 @@ export default async function deploy(isVerbose: string, isProd: string) {
     const buildTime = stamp();
     report.log('Build started...');
 
-    const bundle = await build(entryFiles, isVerbose);
+    const bundle = await build(path, entryFiles, isVerbose);
 
     if (bundle.errors.length > 0) {
       bundle.errors.forEach(({message}) => report.error(message));


### PR DESCRIPTION
Fixes #7

Well, the goal is to provide OOTB TypeScript support without having to add extra configuration to get started. The implementation is also not opinionated about the settings so we use `@babel/preset-typescript` which does not do type checking at build time and will not degrade build time performance.

As part of the support also adding some cache level settings for webpack and for babel itself, this brings considerably decreases the build time for larger projects and medium projects, decreasing around 11x in some cases 🎉.

To show some examples, considering some examples from our [collection of examples](https://github.com/fleetfn/examples):

| Example        | Old           | New  | Gain |
| ------------- |-------------|-------------|-------------|
| faunadb      | 9s | 769ms | 11x |
| simple-http-endpoint | 1s      |    655ms | 1.4x |

It is considered that projects that have more dependencies or more Functions are the big beneficiaries because very simple functions like an echo function despite having a very good improvement does not have much effect.