### PR TITLE
cli: fix error when not invoking function correctly when exists query in URL

### DIFF
--- a/packages/cli/src/commands/dev/router.ts
+++ b/packages/cli/src/commands/dev/router.ts
@@ -30,6 +30,8 @@ async function shouldFunctionCompiled(workfunc: FunctionManifest) {
     return;
   }
 
+  report.log('The function file has not been compiled yet. Awaiting...');
+
   const time = new Date();
 
   fs.utimesSync(workfunc.sourceFilePath, time, time);


### PR DESCRIPTION
Making a request to a URL that has a `query` does not satisfy the match mechanism to determine which function should be invoked, it fixes this by ignoring the `query` and just using the pathname.

```
http://localhost:9000/foo/bar?q=id
```