### PR TITLE
Adds new simulation methods for request and response

### DIFF
--- a/packages/cli/src/commands/dev/request.ts
+++ b/packages/cli/src/commands/dev/request.ts
@@ -43,6 +43,7 @@ export const request = async (req: IncomingMessage) => {
   return {
     headers: getHeaders(req.headers),
     body,
+    ip: req.socket.remoteAddress,
     url: req.url,
     method: req.method,
     query: getQuery(req),


### PR DESCRIPTION
For `response` adds the `ip` property and for `request` a new `preSend` method which is called when `send` is called, will be available in the next version of the Fleet.